### PR TITLE
Added (optional) volume docker-entrypoint-init.d

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,6 +15,14 @@ if [ "$1" = 'sentry' ]; then
 		echo "$line" >> "$defaultConf"
 	fi
 	
+	[ -d /docker-entrypoint-init.d ] && for f in /docker-entrypoint-init.d/*; do
+		case "$f" in
+			*.sh)  echo "$0: running $f"; . "$f" ;;
+			*)     echo "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+
 	# TODO sentry upgrade?
 	# it requires stdin to answer questions and dies on 'unexpected EOF'
 	# but does not ask again when run a second time


### PR DESCRIPTION
Now you can run your custom scripts before each sentry launch. Could fix #23?