### PR TITLE
Bump SENTRY_VERSION to 8.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install python-memcached
 # You'll need to install the required dependencies for Redis buffers:
 RUN pip install redis hiredis nydus
 
-ENV SENTRY_VERSION 7.7.0
+ENV SENTRY_VERSION 8.0.0
 
 RUN pip install sentry==$SENTRY_VERSION
 


### PR DESCRIPTION
Managed to upgrade my existing sentry containers without issues. Using this compose setup: https://github.com/marksteve/compose-sentry