### PR TITLE
Add MySQL support for Docker Sentry

### DIFF
--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PIP_NO_CACHE_DIR off
 ENV PIP_DISABLE_PIP_VERSION_CHECK on
 
-ENV SENTRY_VERSION 8.3.1
+ENV SENTRY_VERSION 8.3.2
 
 RUN pip install sentry==$SENTRY_VERSION  mysqlclient==1.3.7
 

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxml2-dev \
         libxslt-dev \
         libyaml-dev \
+        libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Sane defaults for pip
@@ -17,7 +18,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK on
 
 ENV SENTRY_VERSION 8.3.1
 
-RUN pip install sentry==$SENTRY_VERSION
+RUN pip install sentry==$SENTRY_VERSION  mysqlclient==1.3.7
 
 ENV SENTRY_CONF=/etc/sentry \
     SENTRY_FILESTORE_DIR=/var/lib/sentry/files

--- a/8.3/docker-compose.yml
+++ b/8.3/docker-compose.yml
@@ -1,0 +1,44 @@
+redis:
+  image: redis:latest
+  ports:
+    - "6379:6379"
+
+mysql:
+  image: mysql:5.5
+  ports:
+    - "3306:3306"
+  environment:
+    - MYSQL_ROOT_PASSWORD=passowrd
+    - MYSQL_USER=sentry
+    - MYSQL_PASSWORD=password
+    - MYSQL_DATABASE=sentry
+  command: docker-entrypoint.sh --character-set-server=utf8 --collation-server=utf8_unicode_ci
+
+sentry-mysql:
+#  build: /home/maven/docker-sentry/8.3
+  image: sentry_sentry-mysql
+  ports:
+    - "8080:9000"
+  environment:
+    - SENTRY_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  links:
+    - redis:redis
+    - mysql:mysql
+
+sentry-mysql-celery-beat:
+  image: sentry_sentry-mysql
+  environment:
+    - SENTRY_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  links:
+    - redis:redis
+    - mysql:mysql
+  command: sentry celery beat
+
+sentry-mysql-celery-worker:
+  image: sentry_sentry-mysql
+  environment:
+    - SENTRY_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  links:
+    - redis:redis
+    - mysql:mysql
+  command: sentry celery worker

--- a/8.3/sentry.conf.py
+++ b/8.3/sentry.conf.py
@@ -30,7 +30,8 @@ import os.path
 
 CONF_ROOT = os.path.dirname(__file__)
 
-postgres = os.environ.get('SENTRY_POSTGRES_HOST') or (os.environ.get('POSTGRES_PORT_5432_TCP_ADDR') and 'postgres')
+mysql = os.environ.get('SENTRY_MYSQL_HOST') or os.environ.get('MYSQL_PORT_3306_TCP_ADDR')
+postgres = os.environ.get('SENTRY_POSTGRES_HOST') or os.environ.get('POSTGRES_PORT_5432_TCP_ADDR')
 if postgres:
     DATABASES = {
         'default': {
@@ -54,6 +55,34 @@ if postgres:
             'PORT': (
                 os.environ.get('SENTRY_POSTGRES_PORT')
                 or ''
+            ),
+            'OPTIONS': {
+                'autocommit': True,
+            },
+        },
+    }
+elif mysql:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': (
+                os.environ.get('SENTRY_DB_NAME')
+                or os.environ.get('MYSQL_ENV_MYSQL_DATABASE')
+                or 'sentry'
+            ),
+            'USER': (
+                os.environ.get('SENTRY_DB_USER')
+                or os.environ.get('MYSQL_ENV_MYSQL_USER')
+                or 'remote'
+            ),
+            'PASSWORD': (
+                os.environ.get('SENTRY_DB_PASSWORD')
+                or os.environ.get('MYSQL_ENV_MYSQL_PASSWORD')
+                or ''
+            ),
+            'HOST': mysql,
+            'PORT': (
+                os.environ.get('SENTRY_MYSQL_PORT') or ''
             ),
             'OPTIONS': {
                 'autocommit': True,


### PR DESCRIPTION
These changes add the support for MySQL as sentry database. Tested with Sentry 8.3.2 and MySQL 5.5 community editor.

I know this may very well to be anticlimactic given that Sentry is planning to drop support for MySQL. But I am really hoping my work here can be shared to the community and be useful in the mean time.

Let me know if there is any change to be made in order to be able to get merged in.