### PR TITLE
Convert "generate-stackbrew-library.sh" to output the new 2822-based format

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,44 +1,86 @@
 #!/bin/bash
-set -e
+set -eu
 
 declare -A aliases
 aliases=(
 	[8.5]='8 latest'
 )
 
+self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-url='git://github.com/getsentry/docker-sentry'
 
-echo '# maintainer: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)'
+# get the most recent commit which modified any of "$@"
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+dirCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir"
+		fileCommit \
+			Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++) {
+						print $i
+					}
+				}
+			')
+	)
+}
+
+cat <<-EOH
+# this file is generated via https://github.com/getsentry/docker-sentry/blob/$(fileCommit "$self")/$self
+
+Maintainers: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
+GitRepo: https://github.com/getsentry/docker-sentry.git
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
 
 for version in "${versions[@]}"; do
 	# Ignore git/test folders
 	[ "$version" = git ] && continue
 	[ "$version" = test ] && continue
 
-	commit="$(cd "$version" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
-	fullVersion="$(grep -m1 'ENV SENTRY_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
-	versionAliases=( $fullVersion $version ${aliases[$version]} )
+	commit="$(dirCommit "$version")"
+
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "SENTRY_VERSION" { print $3; exit }')"
+
+	versionAliases=( $fullVersion )
+	if [ "$version" != "$fullVersion" ]; then
+		versionAliases+=( $version )
+	fi
+	versionAliases+=( ${aliases[$version]:-} )
 
 	echo
-	for va in "${versionAliases[@]}"; do
-		echo "$va: ${url}@${commit} $version"
-	done
+	cat <<-EOE
+		Tags: $(join ', ' "${versionAliases[@]}")
+		GitCommit: $commit
+		Directory: $version
+	EOE
 
 	for variant in onbuild; do
-		[ -f "$version/$variant/Dockerfile" ] || continue
-		commit="$(cd "$version/$variant" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
+		commit="$(dirCommit "$version/$variant")"
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
 		echo
-		for va in "${versionAliases[@]}"; do
-			if [ "$va" = 'latest' ]; then
-				va="$variant"
-			else
-				va="$va-$variant"
-			fi
-			echo "$va: ${url}@${commit} $version/$variant"
-		done
+		cat <<-EOE
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $version/$variant
+		EOE
 	done
 done


### PR DESCRIPTION
@tianon @yosifkit 

This is mostly a copy/paste from what you're doing over there on other images.

The output at HEAD is:

```
Maintainers: Matt Robenolt <matt@getsentry.com> (@mattrobenolt)
GitRepo: https://github.com/getsentry/docker-sentry.git

Tags: 8.4.1-onbuild, 8.4-onbuild
GitCommit: 80218c227b188fad17575040421d600303c5f7bf
Directory: 8.4/onbuild

Tags: 8.4.1, 8.4
GitCommit: 80218c227b188fad17575040421d600303c5f7bf
Directory: 8.4

Tags: 8.5.1-onbuild, 8.5-onbuild, 8-onbuild, onbuild
GitCommit: ce5121a71f55c2fb0659f552e361b1174c85bccf
Directory: 8.5/onbuild

Tags: 8.5.1, 8.5, 8, latest
GitCommit: ce5121a71f55c2fb0659f552e361b1174c85bccf
Directory: 8.5
```

This _seems_ ok.