### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/8.4/sentry.conf.py
+++ b/8.4/sentry.conf.py
@@ -219,7 +219,7 @@ SENTRY_DIGESTS = 'sentry.digests.backends.redis.RedisBackend'
 ################
 
 # Any Django storage backend is compatible with Sentry. For more solutions see
-# the django-storages package: https://django-storages.readthedocs.org/en/latest/
+# the django-storages package: https://django-storages.readthedocs.io/en/latest/
 
 SENTRY_FILESTORE = 'django.core.files.storage.FileSystemStorage'
 SENTRY_FILESTORE_OPTIONS = {

--- a/8.5/sentry.conf.py
+++ b/8.5/sentry.conf.py
@@ -219,7 +219,7 @@ SENTRY_DIGESTS = 'sentry.digests.backends.redis.RedisBackend'
 ################
 
 # Any Django storage backend is compatible with Sentry. For more solutions see
-# the django-storages package: https://django-storages.readthedocs.org/en/latest/
+# the django-storages package: https://django-storages.readthedocs.io/en/latest/
 
 SENTRY_FILESTORE = 'django.core.files.storage.FileSystemStorage'
 SENTRY_FILESTORE_OPTIONS = {

--- a/git/sentry.conf.py
+++ b/git/sentry.conf.py
@@ -219,7 +219,7 @@ SENTRY_DIGESTS = 'sentry.digests.backends.redis.RedisBackend'
 ################
 
 # Any Django storage backend is compatible with Sentry. For more solutions see
-# the django-storages package: https://django-storages.readthedocs.org/en/latest/
+# the django-storages package: https://django-storages.readthedocs.io/en/latest/
 
 SENTRY_FILESTORE = 'django.core.files.storage.FileSystemStorage'
 SENTRY_FILESTORE_OPTIONS = {


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.