### PR TITLE
Allow configuration of StatsD metrics backend

### DIFF
--- a/8.22/sentry.conf.py
+++ b/8.22/sentry.conf.py
@@ -33,6 +33,8 @@
 #  GITHUB_API_SECRET
 #  BITBUCKET_CONSUMER_KEY
 #  BITBUCKET_CONSUMER_SECRET
+#  SENTRY_STATSD_HOST
+#  SENTRY_STATSD_PORT
 from sentry.conf.server import *  # NOQA
 
 import os
@@ -304,3 +306,10 @@ if 'GITHUB_APP_ID' in os.environ:
 if 'BITBUCKET_CONSUMER_KEY' in os.environ:
     BITBUCKET_CONSUMER_KEY = env('BITBUCKET_CONSUMER_KEY')
     BITBUCKET_CONSUMER_SECRET = env('BITBUCKET_CONSUMER_SECRET')
+
+if 'SENTRY_STATSD_HOST' in os.environ or 'SENTRY_STATSD_PORT' in os.environ:
+    SENTRY_METRICS_BACKEND = 'sentry.metrics.statsd.StatsdMetricsBackend'
+    SENTRY_METRICS_OPTIONS = {
+        'host': env('SENTRY_STATSD_HOST', 'localhost'),
+        'port': int(env('SENTRY_STATSD_PORT', 8125)),
+    }

--- a/8.22/sentry.conf.py
+++ b/8.22/sentry.conf.py
@@ -35,6 +35,8 @@
 #  BITBUCKET_CONSUMER_SECRET
 #  SENTRY_STATSD_HOST
 #  SENTRY_STATSD_PORT
+#  SENTRY_DOGSTATSD_HOST
+#  SENTRY_DOGSTATSD_PORT
 from sentry.conf.server import *  # NOQA
 
 import os
@@ -312,4 +314,10 @@ if 'SENTRY_STATSD_HOST' in os.environ or 'SENTRY_STATSD_PORT' in os.environ:
     SENTRY_METRICS_OPTIONS = {
         'host': env('SENTRY_STATSD_HOST', 'localhost'),
         'port': int(env('SENTRY_STATSD_PORT', 8125)),
+    }
+elif 'SENTRY_DOGSTATSD_HOST' in os.environ or 'SENTRY_DOGSTATSD_PORT' in os.environ:
+    SENTRY_METRICS_BACKEND = 'sentry.metrics.dogstatsd.DogStatsdMetricsBackend'
+    SENTRY_METRICS_OPTIONS = {
+        'statsd_host': env('SENTRY_DOGSTATSD_HOST', 'localhost'),
+        'statsd_port': int(env('SENTRY_DOGSTATSD_PORT', 8125)),
     }

--- a/9.0/sentry.conf.py
+++ b/9.0/sentry.conf.py
@@ -38,6 +38,8 @@
 #  BITBUCKET_CONSUMER_SECRET
 #  SENTRY_STATSD_HOST
 #  SENTRY_STATSD_PORT
+#  SENTRY_DOGSTATSD_HOST
+#  SENTRY_DOGSTATSD_PORT
 from sentry.conf.server import *  # NOQA
 
 import os
@@ -324,4 +326,10 @@ if 'SENTRY_STATSD_HOST' in os.environ or 'SENTRY_STATSD_PORT' in os.environ:
     SENTRY_METRICS_OPTIONS = {
         'host': env('SENTRY_STATSD_HOST', 'localhost'),
         'port': int(env('SENTRY_STATSD_PORT', 8125)),
+    }
+elif 'SENTRY_DOGSTATSD_HOST' in os.environ or 'SENTRY_DOGSTATSD_PORT' in os.environ:
+    SENTRY_METRICS_BACKEND = 'sentry.metrics.dogstatsd.DogStatsdMetricsBackend'
+    SENTRY_METRICS_OPTIONS = {
+        'statsd_host': env('SENTRY_DOGSTATSD_HOST', 'localhost'),
+        'statsd_port': int(env('SENTRY_DOGSTATSD_PORT', 8125)),
     }

--- a/9.0/sentry.conf.py
+++ b/9.0/sentry.conf.py
@@ -36,6 +36,8 @@
 #  GITHUB_API_SECRET
 #  BITBUCKET_CONSUMER_KEY
 #  BITBUCKET_CONSUMER_SECRET
+#  SENTRY_STATSD_HOST
+#  SENTRY_STATSD_PORT
 from sentry.conf.server import *  # NOQA
 
 import os
@@ -316,3 +318,10 @@ if 'GITHUB_APP_ID' in os.environ:
 if 'BITBUCKET_CONSUMER_KEY' in os.environ:
     BITBUCKET_CONSUMER_KEY = env('BITBUCKET_CONSUMER_KEY')
     BITBUCKET_CONSUMER_SECRET = env('BITBUCKET_CONSUMER_SECRET')
+
+if 'SENTRY_STATSD_HOST' in os.environ or 'SENTRY_STATSD_PORT' in os.environ:
+    SENTRY_METRICS_BACKEND = 'sentry.metrics.statsd.StatsdMetricsBackend'
+    SENTRY_METRICS_OPTIONS = {
+        'host': env('SENTRY_STATSD_HOST', 'localhost'),
+        'port': int(env('SENTRY_STATSD_PORT', 8125)),
+    }

--- a/git/sentry.conf.py
+++ b/git/sentry.conf.py
@@ -29,6 +29,8 @@
 #  SENTRY_MAILGUN_API_KEY
 #  SENTRY_SINGLE_ORGANIZATION
 #  SENTRY_SECRET_KEY
+#  SENTRY_STATSD_HOST
+#  SENTRY_STATSD_PORT
 from sentry.conf.server import *  # NOQA
 from sentry.utils.types import Bool
 
@@ -292,3 +294,10 @@ if 'SENTRY_RUNNING_UWSGI' not in os.environ and len(secret_key) < 32:
     print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
 
 SENTRY_OPTIONS['system.secret-key'] = secret_key
+
+if 'SENTRY_STATSD_HOST' in os.environ or 'SENTRY_STATSD_PORT' in os.environ:
+    SENTRY_METRICS_BACKEND = 'sentry.metrics.statsd.StatsdMetricsBackend'
+    SENTRY_METRICS_OPTIONS = {
+        'host': env('SENTRY_STATSD_HOST', 'localhost'),
+        'port': int(env('SENTRY_STATSD_PORT', 8125)),
+    }

--- a/git/sentry.conf.py
+++ b/git/sentry.conf.py
@@ -31,6 +31,8 @@
 #  SENTRY_SECRET_KEY
 #  SENTRY_STATSD_HOST
 #  SENTRY_STATSD_PORT
+#  SENTRY_DOGSTATSD_HOST
+#  SENTRY_DOGSTATSD_PORT
 from sentry.conf.server import *  # NOQA
 from sentry.utils.types import Bool
 
@@ -300,4 +302,10 @@ if 'SENTRY_STATSD_HOST' in os.environ or 'SENTRY_STATSD_PORT' in os.environ:
     SENTRY_METRICS_OPTIONS = {
         'host': env('SENTRY_STATSD_HOST', 'localhost'),
         'port': int(env('SENTRY_STATSD_PORT', 8125)),
+    }
+elif 'SENTRY_DOGSTATSD_HOST' in os.environ or 'SENTRY_DOGSTATSD_PORT' in os.environ:
+    SENTRY_METRICS_BACKEND = 'sentry.metrics.dogstatsd.DogStatsdMetricsBackend'
+    SENTRY_METRICS_OPTIONS = {
+        'statsd_host': env('SENTRY_DOGSTATSD_HOST', 'localhost'),
+        'statsd_port': int(env('SENTRY_DOGSTATSD_PORT', 8125)),
     }


### PR DESCRIPTION
If either `SENTRY_STATSD_HOST` or `SENTRY_STATSD_PORT` is defined as environment
variables the StatsD metrics backend will be enabled and use the provided
settings to the configuration. If either the host or port is not defined they
will default to use a hostname of 'localhost' and port of 8125.
https://docs.sentry.io/server/internal-metrics/