### PR TITLE
Add Slack environment variables

### DIFF
--- a/9.0/sentry.conf.py
+++ b/9.0/sentry.conf.py
@@ -29,6 +29,9 @@
 #  SENTRY_MAILGUN_API_KEY
 #  SENTRY_SINGLE_ORGANIZATION
 #  SENTRY_SECRET_KEY
+#  SLACK_CLIENT_ID
+#  SLACK_CLIENT_SECRET
+#  SLACK_VERIFICATION_TOKEN
 #  GITHUB_APP_ID
 #  GITHUB_API_SECRET
 #  BITBUCKET_CONSUMER_KEY
@@ -278,6 +281,15 @@ else:
 
 if SENTRY_OPTIONS['mail.enable-replies']:
     SENTRY_OPTIONS['mail.reply-hostname'] = env('SENTRY_SMTP_HOSTNAME') or ''
+
+#####################
+# SLACK INTEGRATION #
+#####################
+slack = env('SLACK_CLIENT_ID') and env('SLACK_CLIENT_SECRET')
+if slack:
+    SENTRY_OPTIONS['slack.client-id'] = env('SLACK_CLIENT_ID')
+    SENTRY_OPTIONS['slack.client-secret'] = env('SLACK_CLIENT_SECRET')
+    SENTRY_OPTIONS['slack.verification-token'] = env('SLACK_VERIFICATION_TOKEN') or ''
 
 # If this value ever becomes compromised, it's important to regenerate your
 # SENTRY_SECRET_KEY. Changing this value will result in all current sessions


### PR DESCRIPTION
In order to get Slack integration working with on-prem setups, you need a Slack Sentry app configured with client ID and secret.
This can be specified via config.yml, but much easier to stick it in the ENV

```
# env | grep SLACK
SLACK_CLIENT_ID=4444444444.444444444444
SLACK_CLIENT_SECRET=88888888888888888888888888888888888888
```

```
# sentry shell

10:57:02 [INFO] sentry.plugins.github: apps-not-configured
Python 2.7.15 (default, Jul 31 2018, 23:08:29)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>>
>>> from sentry import options
>>> print(options.get('slack.client-id'))
4444444444.444444444444
>>> print(options.get('slack.client-secret'))
88888888888888888888888888888888888888
```