### PR TITLE
Bump Node to v8.15.0 to fix build-git.sh ESLint dependency

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -61,7 +61,7 @@ ENV SENTRY_BUILD $SENTRY_BUILD
 
 RUN [ "$SENTRY_BUILD" != '' ] \
     # Install node to build assets
-    && export NODE_VERSION=8.9.1 \
+    && export NODE_VERSION=8.15.0 \
     && export YARN_VERSION=1.3.2 \
     && export GNUPGHOME="$(mktemp -d)" \
     && export NPM_CONFIG_CACHE="$(mktemp -d)" \


### PR DESCRIPTION
ESLint fails the build with the current version of node (8.9.1), bumping to 8.15.0 fixes the failure.

```bash
...
running build_integration_docs
using node (v8.9.1) and yarn (1.3.2)
error eslint@5.11.1: The engine "node" is incompatible with this module. Expected version "^6.14.0 || ^8.10.0 || >=9.10.0".
error Found incompatible module
command failed [yarn install --production --pure-lockfile] via [/usr/src/sentry]
Traceback (most recent call last):
  File "setup.py", line 160, in <module>
    'Topic :: Software Development'
  File "/usr/local/lib/python2.7/site-packages/setuptools/__init__.py", line 143, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/local/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 188, in run
    self.run_command('build')
  File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "setup.py", line 102, in run
    self.run_command('build_integration_docs')
  File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/src/sentry/src/sentry/utils/distutils/commands/base.py", line 186, in run
    self._setup_npm()
  File "/usr/src/sentry/src/sentry/utils/distutils/commands/base.py", line 141, in _setup_npm
    ['yarn', 'install', '--production', '--pure-lockfile']
  File "/usr/src/sentry/src/sentry/utils/distutils/commands/base.py", line 150, in _run_command
    return check_output(cmd, cwd=self.work_path, env=env)
  File "/usr/local/lib/python2.7/subprocess.py", line 223, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['yarn', 'install', '--production', '--pure-lockfile']' returned non-zero exit status 1
```