### PR TITLE
Bump base image to python:2.7.16-slim-jessie

### DIFF
--- a/8.22/Dockerfile
+++ b/8.22/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14-slim
+FROM python:2.7.16-slim-jessie
 
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r sentry && useradd -r -m -g sentry sentry

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.15-slim-jessie
+FROM python:2.7.16-slim-jessie
 
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r sentry && useradd -r -m -g sentry sentry

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,5 +1,5 @@
 # Build from any git sha by passing `--build-arg SENTRY_BUILD=<sha>`
-FROM python:2.7.15-slim-jessie
+FROM python:2.7.16-slim-jessie
 
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r sentry && useradd -r -m -g sentry sentry


### PR DESCRIPTION
The current base image has caused image builds to fail in the last couple of days. This is because some Jessie APT repos are no longer mirrored and thus apt-get update errors out with a 404.

Bumping to 2.7.16 ought to fix it (see comment here https://github.com/getsentry/docker-sentry/issues/140#issuecomment-477370223)