### PR TITLE
fix(update): Fix version detection in update

### DIFF
--- a/build-git.sh
+++ b/build-git.sh
@@ -7,7 +7,7 @@ usage () {
 }
 
 if [ "$#" = 0 ]; then
-    set -- "$(curl -sSL 'https://api.github.com/repos/getsentry/sentry/git/refs/heads/master' | awk -F '"' '$2 == "sha" { print $4 }')"
+    set -- "$(curl -sSL 'https://api.github.com/repos/getsentry/sentry/git/refs/heads/master' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
     echo "No sha specified, using refs/head/master ($1)"
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-current="$(curl -sSL 'https://pypi.python.org/pypi/sentry/json' | awk -F '"' '$2 == "version" { print $4 }')"
+current="$(curl -sSL 'https://pypi.python.org/pypi/sentry/json' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "version" { print $4 }')"
 
 set -x
 sed -ri 's/^(ENV SENTRY_VERSION) .*/\1 '"$current"'/' 9.1/Dockerfile


### PR DESCRIPTION
Fixes our `awk` magic to "parse" JSON responses so it can work
both with and without newlines in responses. PIP does not
format its JSON output whereas GitHub does.

Supersedes #156.