### PR TITLE
ci(travis): Remove reduntant Travis CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services: docker
 env:
   - VERSION=9.0
   - VERSION=9.1
-  - VERSION=git
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
@@ -21,12 +20,6 @@ script:
   - docker build -t "$image-onbuild" onbuild
   - ~/official-images/test/run.sh "$image-onbuild"
   - $TRAVIS_BUILD_DIR/test/run.sh "$image-onbuild"
-  - >
-    if [ "$VERSION" == "git" -a "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
-      docker push "$image";
-      docker push "$image-onbuild";
-    fi
 
 after_script:
   - docker images


### PR DESCRIPTION
`git` and `git-onbuild` images are now tested, built, and
published by Docker Hub so remove these steps from
Travis CI config.