### PR TITLE
ref(git): Switch git builds to multi-stage builds

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -106,7 +106,11 @@ RUN gosu nobody true \
     " \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps \
-    && pip install /tmp/dist/*.whl librabbitmq==1.6.1 maxminddb==1.4.1 \
+    && pip install /tmp/dist/*.whl \
+    # Separate these due to https://git.io/fjyz6
+    # Otherwise librabbitmq will install the latest amqp version,
+    # violating kombu's amqp<2.0 constraint.
+    && pip install librabbitmq==1.6.1 maxminddb==1.4.1 \
     && rm -rf /tmp/dist \
     && apt-get purge -y --auto-remove $buildDeps \
     # We install run-time dependencies strictly after

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -51,7 +51,7 @@ RUN set -x \
     && chmod +x /usr/local/bin/tini
 
 # Get and set up Node for front-end asset building
-ENV NODE_VERSION 8.16.0
+ENV NODE_VERSION 10.16.3
 RUN wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
     && wget "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --verify SHASUMS256.txt.asc \

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -92,8 +92,7 @@ ENV PIP_NO_CACHE_DIR=off \
     UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false
 
 COPY --from=sdist /dist/*.whl /tmp/dist/
-RUN gosu nobody true \
-    && set -x \
+RUN set -x \
     && buildDeps="" \
     # uwsgi
     && buildDeps="$buildDeps \

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -128,8 +128,6 @@ RUN set -x \
       libffi-dev \
       # maxminddb bindings
       libmaxminddb-dev \
-      # geoip bindings
-      libgeoip-dev \
       # SAML needs these run-time
       libxmlsec1-dev \
       libxslt-dev \

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -52,7 +52,6 @@ RUN set -x \
 
 # Get and set up Node for front-end asset building
 ENV NODE_VERSION 8.16.0
-
 RUN wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
     && wget "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --verify SHASUMS256.txt.asc \
@@ -61,6 +60,7 @@ RUN wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.t
     && rm -r "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
 ARG SENTRY_BUILD=master
+ENV SENTRY_BUILD $SENTRY_BUILD
 RUN [ "$SENTRY_BUILD" != '' ] \
     && mkdir -p /usr/src/sentry \
     && cd /usr/src/sentry \

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -90,63 +90,49 @@ ENV PIP_NO_CACHE_DIR=off \
 COPY --from=sdist /dist/*.whl /tmp/dist/
 RUN gosu nobody true \
     && set -x \
-    && uwsgiBuildDeps=" \
+    && buildDeps="" \
+    # uwsgi
+    && buildDeps="$buildDeps \
       gcc \
       g++ \
     " \
-    && maxminddbBuildDeps=" \
+    # maxminddb
+    && buildDeps="$buildDeps \
       libmaxminddb-dev \
     "\
-    && libRabbitmqBuildDeps=" \
+    # librabbitmq
+    && buildDeps="$buildDeps \
       make \
-    " \
-    && buildDeps=" \
-      $uwsgiBuildDeps \
-      $maxminddbBuildDeps \
-      $libRabbitmqBuildDeps \
     " \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps \
     && pip install /tmp/dist/*.whl librabbitmq==1.6.1 maxminddb==1.4.1 \
     && rm -rf /tmp/dist \
     && apt-get purge -y --auto-remove $buildDeps \
-    \
-    && pillowDeps=" \
+    # We install run-time dependencies strictly after
+    # build dependencies to prevent accidental collusion.
+    # These are also installed last as they are needed
+    # during container run and can have the same deps w/
+    # build deps such as maxminddb.
+    && apt-get install -y --no-install-recommends \
+      # pillow
       libjpeg-dev \
-    " \
-    && rustDeps=" \
+      # rust bindings
       libffi-dev \
-    " \
-    && maxminddbDeps=" \
-       libmaxminddb-dev \
-    " \
-    && uwsgiDeps=" \
+      # maxminddb bindings
+      libmaxminddb-dev \
+      # uwsgi needs this run-time
       libxml2-dev \
-    " \
-    && geoipDeps=" \
+      # geoip bindings
       libgeoip-dev \
-    " \
-    && samlDeps=" \
+      # SAML needs these run-time
       libxmlsec1-dev \
       libxslt-dev \
-    " \
-    && pyyamlDeps=" \
+      # pyyaml needs this run-time
       libyaml-dev \
-    " \
-    && otherRuntimeDeps=" \
+      # other
       pkg-config \
-    " \
-    && runtimeDeps=" \
-      $pillowDeps \
-      $rustDeps \
-      $maxminddbDeps \
-      $uwsgiDeps \
-      $geoipDeps \
-      $samlDeps \
-      $pyyamlDeps \
-      $otherRuntimeDeps \
-    " \
-    && apt-get install -y --no-install-recommends $runtimeDeps \
+    \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && python -c 'import librabbitmq' \
@@ -155,11 +141,10 @@ RUN gosu nobody true \
     && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
     && mkdir -p $SENTRY_CONF && mkdir -p $SENTRY_FILESTORE_DIR
 
-COPY docker-entrypoint.sh /entrypoint.sh
-COPY sentry.conf.py config.yml $SENTRY_CONF/
+COPY docker-entrypoint.sh sentry.conf.py config.yml $SENTRY_CONF/
 
 EXPOSE 9000
 VOLUME /var/lib/sentry/files
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT exec $SENTRY_CONF/docker-entrypoint.sh $0 $@
 CMD ["run", "web"]

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -83,9 +83,12 @@ COPY --from=sdist /usr/local/bin/gosu /usr/local/bin/tini /usr/local/bin/
 # Sane defaults for pip
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-# Sentry config params
+    # Sentry config params
     SENTRY_CONF=/etc/sentry \
-    SENTRY_FILESTORE_DIR=/var/lib/sentry/files
+    SENTRY_FILESTORE_DIR=/var/lib/sentry/files \
+    # Disable some unused uWSGI features, saving dependencies
+    # Thank to https://stackoverflow.com/a/25260588/90297
+    UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false
 
 COPY --from=sdist /dist/*.whl /tmp/dist/
 RUN gosu nobody true \
@@ -125,8 +128,6 @@ RUN gosu nobody true \
       libffi-dev \
       # maxminddb bindings
       libmaxminddb-dev \
-      # uwsgi needs this run-time
-      libxml2-dev \
       # geoip bindings
       libgeoip-dev \
       # SAML needs these run-time

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,107 +1,21 @@
 # Build from any git sha by passing `--build-arg SENTRY_BUILD=<sha>`
-FROM python:2.7.16-slim-stretch
-
-# add our user and group first to make sure their IDs get assigned consistently
-RUN groupadd -r sentry && useradd -r -m -g sentry sentry
+FROM python:2.7.16-slim-stretch as sdist
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gcc \
-        git \
-        libffi-dev \
-        libgeoip-dev \
-        libjpeg-dev \
-        libmaxminddb-dev \
-        libxml2-dev \
-        libxmlsec1-dev \
-        libxslt-dev \
-        libyaml-dev \
-        pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+    # Needed for GPG
+    dirmngr \
+    gnupg \
+    # Needed for fetching stuff
+    wget \
+  && rm -rf /var/lib/apt/lists/*
 
-# Sane defaults for pip
-ENV PIP_NO_CACHE_DIR off
-ENV PIP_DISABLE_PIP_VERSION_CHECK on
-
-# grab gosu for easy step-down from root
-RUN set -x \
-    && export GOSU_VERSION=1.11 \
-    && fetchDeps=" \
-        dirmngr \
-        gnupg \
-        wget \
-    " \
-    && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && for key in \
+# Fetch trusted keys
+RUN for key in \
+      # gosu
       B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    ; do \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-    done \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && gpgconf --kill all \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true \
-    && apt-get purge -y --auto-remove $fetchDeps
-
-# grab tini for signal processing and zombie killing
-RUN set -x \
-    && export TINI_VERSION=0.18.0 \
-    && fetchDeps=" \
-        dirmngr \
-        gnupg \
-        wget \
-    " \
-    && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
-    && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini" \
-    && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && for key in \
+      # tini
       595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    ; do \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-    done \
-    && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
-    && gpgconf --kill all \
-    && rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
-    && chmod +x /usr/local/bin/tini \
-    && tini -h \
-    && apt-get purge -y --auto-remove $fetchDeps
-
-# Support for RabbitMQ and GeoIP
-RUN set -x \
-    && apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/* \
-    && pip install librabbitmq==1.6.1 maxminddb==1.4.1 \
-    && python -c 'import librabbitmq' \
-    # Fully verify that the C extension is correctly installed, it unfortunately
-    # requires a full check into maxminddb.extension.Reader
-    && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
-    && apt-get purge -y --auto-remove make
-
-ARG SENTRY_BUILD=master
-ENV SENTRY_BUILD $SENTRY_BUILD
-
-RUN [ "$SENTRY_BUILD" != '' ] \
-    # Install node to build assets
-    && export NODE_VERSION=8.15.1 \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && export YARN_CACHE_FOLDER="$(mktemp -d)" \
-    && buildDeps=" \
-        g++ \
-        dirmngr \
-        gnupg \
-        wget \
-    " \
-    && apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-    # gpg keys listed at https://github.com/nodejs/node
-    && set -ex \
-    && for key in \
+      # Node - gpg keys listed at https://github.com/nodejs/node
       94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
       FD3A5288F042B6850C66B31F09FE44734EB7990E \
       71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
@@ -114,43 +28,135 @@ RUN [ "$SENTRY_BUILD" != '' ] \
       A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
       B9E2F5981AA6E0CD28160D9FF13993A75599653C \
     ; do \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-    done \
-    && mkdir -p /usr/local/node && PATH=/usr/local/node/bin:$PATH \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+      # TODO(byk): Replace the keyserver below w/ something owned by Sentry
+      gpg --batch --keyserver hkps://mattrobenolt-keyserver.global.ssl.fastly.net:443 --recv-keys "$key"; \
+    done
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.11
+RUN set -x \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
+
+# grab tini for signal processing and zombie killing
+ENV TINI_VERSION 0.18.0
+RUN set -x \
+    && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini" \
+    && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini.asc" \
+    && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+    && rm /usr/local/bin/tini.asc \
+    && chmod +x /usr/local/bin/tini
+
+# Get and set up Node for front-end asset building
+ENV NODE_VERSION 8.16.0
+
+RUN wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
     && wget "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --verify SHASUMS256.txt.asc \
-    && gpgconf --kill all \
     && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-    && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local/node --strip-components=1 \
-    && rm -r "$GNUPGHOME" "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
-    \
+    && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+    && rm -r "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
+
+ARG SENTRY_BUILD=master
+RUN [ "$SENTRY_BUILD" != '' ] \
     && mkdir -p /usr/src/sentry \
     && cd /usr/src/sentry \
     && wget -qO - "https://github.com/getsentry/sentry/archive/${SENTRY_BUILD}.tar.gz" | tar -xzf - --strip-components=1 \
+    && export YARN_CACHE_FOLDER="$(mktemp -d)" \
     && python setup.py bdist_wheel \
-    \
-    # Now remove node since it's not needed anymore in the final container
     && rm -r "$YARN_CACHE_FOLDER" \
-    && rm -rf /usr/local/node \
-    \
-    && pip install dist/*.whl \
-    \
-    && apt-get purge -y --auto-remove $buildDeps \
+    && mv /usr/src/sentry/dist /dist \
     && rm -rf /usr/src/sentry
 
-ENV SENTRY_CONF=/etc/sentry \
+
+# This is the image to be run
+FROM python:2.7.16-slim-stretch
+
+# add our user and group first to make sure their IDs get assigned consistently
+RUN groupadd -r sentry && useradd -r -m -g sentry sentry
+
+COPY --from=sdist /usr/local/bin/gosu /usr/local/bin/tini /usr/local/bin/
+
+# Sane defaults for pip
+ENV PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+# Sentry config params
+    SENTRY_CONF=/etc/sentry \
     SENTRY_FILESTORE_DIR=/var/lib/sentry/files
 
-RUN mkdir -p $SENTRY_CONF && mkdir -p $SENTRY_FILESTORE_DIR
-
-COPY sentry.conf.py /etc/sentry/
-COPY config.yml /etc/sentry/
+COPY --from=sdist /dist/*.whl /tmp/dist/
+RUN gosu nobody true \
+    && set -x \
+    && uwsgiBuildDeps=" \
+      gcc \
+      g++ \
+    " \
+    && maxminddbBuildDeps=" \
+      libmaxminddb-dev \
+    "\
+    && libRabbitmqBuildDeps=" \
+      make \
+    " \
+    && buildDeps=" \
+      $uwsgiBuildDeps \
+      $maxminddbBuildDeps \
+      $libRabbitmqBuildDeps \
+    " \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && pip install /tmp/dist/*.whl librabbitmq==1.6.1 maxminddb==1.4.1 \
+    && rm -rf /tmp/dist \
+    && apt-get purge -y --auto-remove $buildDeps \
+    \
+    && pillowDeps=" \
+      libjpeg-dev \
+    " \
+    && rustDeps=" \
+      libffi-dev \
+    " \
+    && maxminddbDeps=" \
+       libmaxminddb-dev \
+    " \
+    && uwsgiDeps=" \
+      libxml2-dev \
+    " \
+    && geoipDeps=" \
+      libgeoip-dev \
+    " \
+    && samlDeps=" \
+      libxmlsec1-dev \
+      libxslt-dev \
+    " \
+    && pyyamlDeps=" \
+      libyaml-dev \
+    " \
+    && otherRuntimeDeps=" \
+      pkg-config \
+    " \
+    && runtimeDeps=" \
+      $pillowDeps \
+      $rustDeps \
+      $maxminddbDeps \
+      $uwsgiDeps \
+      $geoipDeps \
+      $samlDeps \
+      $pyyamlDeps \
+      $otherRuntimeDeps \
+    " \
+    && apt-get install -y --no-install-recommends $runtimeDeps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -c 'import librabbitmq' \
+    # Fully verify that the C extension is correctly installed, it unfortunately
+    # requires a full check into maxminddb.extension.Reader
+    && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
+    && mkdir -p $SENTRY_CONF && mkdir -p $SENTRY_FILESTORE_DIR
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY sentry.conf.py config.yml $SENTRY_CONF/
 
 EXPOSE 9000
 VOLUME /var/lib/sentry/files

--- a/sdist.sh
+++ b/sdist.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+SDIST_IMAGE_NAME=getsentry/sentry:git-sdist
+
+docker build git --target=sdist -t $SDIST_IMAGE_NAME
+id=$(docker create $SDIST_IMAGE_NAME)
+docker cp $id:/dist ./dist
+docker rm -v $id


### PR DESCRIPTION
This diff refactors git/Dockerfile to make use of [multi-stage builds](https://dockr.ly/2TxXT6p) which provides the following benefits:

 - Cleaner separation of `sdist` and `runtime` containers
 - Significantly smaller runtime image (~110MB, -12%)
 - Fewer layers on the runtime image (10 layers, down from 15)
 - Unified release and Docker image builds (no need for `Docker.sdist`)
 - Somewhat more maintainable Dockerfile