### PR TITLE
Fix build-git script when querying master sha

### DIFF
--- a/build-git.sh
+++ b/build-git.sh
@@ -7,7 +7,7 @@ usage () {
 }
 
 if [ "$#" = 0 ]; then
-    set -- "$(curl -sSL 'https://api.github.com/repos/getsentry/sentry/git/refs/heads/master' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
+    set -- "$(curl -sSL 'https://api.github.com/repos/getsentry/sentry/git/refs/heads/master' | jq -r .object.sha)"
     echo "No sha specified, using refs/head/master ($1)"
 fi
 

--- a/build-git.sh
+++ b/build-git.sh
@@ -7,7 +7,7 @@ usage () {
 }
 
 if [ "$#" = 0 ]; then
-    set -- "$(curl -sSL 'https://api.github.com/repos/getsentry/sentry/git/refs/heads/master' | jq -r .object.sha)"
+    set -- "$(curl -sSL 'https://api.github.com/repos/getsentry/sentry/git/refs/heads/master' | grep -Po '(?<=\"sha\": \")([a-f0-9]{5,40})(?=\",?)')"
     echo "No sha specified, using refs/head/master ($1)"
 fi
 


### PR DESCRIPTION
It now requires jq because I'm too lazy to figure out why awk broke.

I couldn't push this to master because it wouldn't let me.